### PR TITLE
refs #1 - update abort method on MQHandler requests

### DIFF
--- a/http/index.js
+++ b/http/index.js
@@ -21,10 +21,10 @@ require("./utils/interceptors").enable(module.exports);
 const PollRequestManager = require("./utils/PollRequestManager");
 const rm = new PollRequestManager(module.exports.fetch);
 
-module.exports.poll = function (url, options, connectionTimeout, delayStart) {
+module.exports.poll = function (url, options, connectionTimeout, delayStart, abortController) {
 	connectionTimeout = connectionTimeout || 10000;
 	rm.setConnectionTimeout(connectionTimeout);
-	const request = rm.createRequest(url, options, delayStart);
+	const request = rm.createRequest(url, options, delayStart, abortController);
 	return request;
 };
 


### PR DESCRIPTION
As descripted in [issue](https://github.com/pccosta-pdm/OpenDSU-core/issues/1):

> We have a situation where we have a wallet containing multiple DIDs that the browser is listening on. However, the browser restricts the number of simultaneous requests that can be made. To address this, we've created a manager to rotate through the DIDs. <br><br>Every so often, the "root" DID sends a message to the DID that needs to be closed, asking it to read the message and finish the request (which is stuck in a loop, because MQ is waiting for new messages).<br><br>However, this approach isn't scalable because, while the browser limits parallel requests to 6 (as an example), the delay in rotating the DIDs and the unnecessary requests for sending messages to cancellations increases as the number of DIDs to be rotated grows.<br><br>There have been some updates to OpenDSU that enable calling methods like "stopWaitingForMessages" However, these checks happen after or before processing, without interrupting or aborting the current request (the DID/MQHandler still keeps the active request even after the "stopWaitingForMessages" method has been called)`.

The pull request suggests the update below while maintaining compatibility with existing functions in public methods and addressing issues related to aborting the request.

#### W3CDID:

- The "readMessage" method in W3CDID now returns the function to abort the request, without exposing the abortController.
- Verification of DID being enabled for reading messages is now checked before calling MQ methods.

#### MQHandler:

- Message reading methods now optionally accept an `abortController` parameter, which is passed throughout the request chain. This allows for aborting the operation at any stage of message processing.
- Fixed empty returns. Even after aborting the request, the callback was still pending, awaiting a response.
- Added a check for the `stopReceivingMessages` parameter before calling a new method or processing. For safety, request abortion is also verified.

#### PollRequestManager:
- Internally, the "Request" method has been refactored to simplify the code
- Unified the methods (destroy and cancelExecution) to abort the request. Now, when an abort occurs, it is caught and rejected by createPollingTask, providing a response to the callback instead of being stuck in a callback with no response.
- `createPollingTask` method has been changed to return a promise instead of using the `setExecutor` method of the Request function and afterwards using the "executers register"(promiseHandlers) to deal with the response. This allows the removal of `resolve` and `reject` methods of the Request function
- `execute` method in the "Request" has been updated to include an abortController in request options.

